### PR TITLE
Chore/diet docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 FROM base AS prod-deps
-RUN npm ci --only=production --omit=dev && \
-    npm cache clean --force
+RUN npm ci --omit=dev && \
+    npm cache clean --forc
 
 FROM base AS build-deps
 RUN npm ci
@@ -19,10 +19,6 @@ RUN npm run build
 FROM base AS runtime
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
-
-# Remove unnecessary files to reduce image size
-RUN rm -rf /app/node_modules/.cache && \
-    rm -rf /app/node_modules/npm
 
 # Set environment variables
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY package.json package-lock.json ./
 
 FROM base AS prod-deps
 RUN npm ci --omit=dev && \
-    npm cache clean --forc
+    npm cache clean --force
 
 FROM base AS build-deps
 RUN npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 FROM base AS prod-deps
-RUN npm install --omit=dev
+RUN npm ci --only=production --omit=dev && \
+    npm cache clean --force
 
 FROM base AS build-deps
-RUN npm install
+RUN npm ci
 
 FROM build-deps AS build
 COPY . .
@@ -19,7 +20,17 @@ FROM base AS runtime
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 
+# Remove unnecessary files to reduce image size
+RUN rm -rf /app/node_modules/.cache && \
+    rm -rf /app/node_modules/npm
+
+# Set environment variables
+ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=4321
+
+# Expose port
 EXPOSE 4321
-CMD node ./dist/server/entry.mjs
+
+# Use JSON array format for CMD (best practice)
+CMD ["node", "./dist/server/entry.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts AS base
+FROM node:lts-alpine AS base
 WORKDIR /app
 
 # By copying only the package.json and package-lock.json here, we ensure that the following `-deps` steps are independent of the source code.


### PR DESCRIPTION
### 도커파일 이미지 크기 줄이기
기존: 1.89GB
알파인 이미지 사용으로 개선: 516MB (70% 감소)

<img width="1121" height="34" alt="image" src="https://github.com/user-attachments/assets/d4efc370-f03f-4be8-81bf-0d9ccd422990" />
