### PR TITLE
Update: Font size and spaces and bubble size

### DIFF
--- a/src/components/card/ActivityCard.astro
+++ b/src/components/card/ActivityCard.astro
@@ -4,12 +4,14 @@ const { name, iconUrl, description } = Astro.props
 
 <div class="grid grid-cols-1">
   <div class="m-auto">
-    <img class="w-[100px]" src={iconUrl} alt="" />
+    <img class="w-[120px] md:w-[140px]" src={iconUrl} alt="" />
   </div>
-  <div class="font-bold m-auto py-6">
+  <div class="font-bold m-auto py-4 text-xl md:text-2xl">
     {name}
   </div>
-  <div class="p-3">
+  <div
+    class="p-3 text-base md:text-lg leading-relaxed text-center md:text-left"
+  >
     {description}
   </div>
 </div>

--- a/src/components/card/ProjectCard.astro
+++ b/src/components/card/ProjectCard.astro
@@ -2,11 +2,11 @@
 const { imageUrl, description } = Astro.props
 ---
 
-<div class="grid grid-cols-1 md:grid-cols-[1fr_3fr] gap-4">
+<div class="grid grid-cols-1 md:grid-cols-[1fr_3fr] gap-6 md:gap-8">
   <div class="flex justify-center">
-    <img class="w-[150px]" src={imageUrl} />
+    <img class="w-[180px] md:w-[220px]" src={imageUrl} />
   </div>
-  <div class="my-auto">
+  <div class="my-auto text-base md:text-lg leading-relaxed">
     {description}
   </div>
 </div>

--- a/src/components/hook/hero.Bubbles.jsx
+++ b/src/components/hook/hero.Bubbles.jsx
@@ -20,13 +20,13 @@ const BubbleClipPath = ({ r, id, ...props }) => (
 // Main component
 const Bubbles = ({
   members,
-  svgWidth = 800,
-  svgHeight = 800,
-  config = { hoverScale: 1.15, imgSize: 100 },
+  svgWidth = 900,
+  svgHeight = 900,
+  config = { hoverScale: 1.15, imgSize: 140 },
 }) => {
   const nodes = members.map((member, i) => ({
     index: i,
-    radius: Math.floor(Math.random() * 30 + 40),
+    radius: Math.floor(Math.random() * 30 + 50),
     x: Math.floor(Math.random() * svgWidth),
     y: Math.floor(Math.random() * svgHeight),
     to: member.html_url,

--- a/src/components/section/Activities.astro
+++ b/src/components/section/Activities.astro
@@ -4,10 +4,10 @@ import activities from '@utils/activities'
 ---
 
 <div class="top-[514px] h-fit w-full p-6 md:px-12 md:py-24">
-  <div class="prose py-12">
-    <h3>Activities</h3>
+  <div class="prose prose-lg md:prose-xl py-12">
+    <h3 class="text-3xl md:text-4xl">Activities</h3>
   </div>
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8">
     {
       activities.activities.map((activity) => {
         return (

--- a/src/components/section/Description.astro
+++ b/src/components/section/Description.astro
@@ -3,7 +3,7 @@
 ---
 
 <div
-  class="h-dvh flex flex-col md:flex-row justify-center md:justify-evenly py-40"
+  class="min-h-[60svh] flex flex-col md:flex-row justify-center md:justify-evenly py-20 md:py-28"
 >
   <div class="w-full md:w-1/2 my-2 md:my-auto">
     <div class="flex justify-center">
@@ -20,17 +20,13 @@
     </div>
   </div>
   <div class="w-full md:w-1/2 text-center my-2 md:my-auto">
-    PoApper 는
-    <span
-      class="before:block before:absolute before:-inset-1 before:-skew-y-1 before:bg-[#E94D4C] relative inline-block"
-    >
-      <span class="relative text-white hover:underline">
-        함께 최신 개발 기술을 익히고 공유하며 성장하는 개발 동아리
+    <p class="text-2xl md:text-3xl leading-relaxed">
+      PoApper는 함께 최신 개발 기술을 익히고 공유하며 성장하는 개발 동아리
       </span>
-    </span>
-    입니다. <br />
-    <div class="p-3">
-      개발 세미나와 해커톤 등을 개최하여 POSTECH 의 개발 문화를 이끌고 있습니다.
-    </div>
+      입니다.
+    </p>
+    <p class="text-xl md:text-2xl mt-6">
+      개발 세미나와 해커톤 등을 개최하여 POSTECH의 개발 문화를 이끌고 있습니다.
+    </p>
   </div>
 </div>

--- a/src/components/section/Hero.astro
+++ b/src/components/section/Hero.astro
@@ -2,25 +2,28 @@
 import BubbleWrapper from '@/components/hook/hero.Bubbles'
 ---
 
-<div class="h-dvh flex flex-col md:flex-row justify-around">
+<div
+  class="min-h-[60svh] flex flex-col md:flex-row items-center justify-between gap-10 py-10"
+>
   <div class="relative flex flex-col justify-center mx-auto">
     <div
-      class="text-4xl font-extrabold bg-gradient-to-r from-[#E94D4C] to-[#52B0E4] text-transparent bg-clip-text mr-auto"
+      class="text-6xl md:text-7xl font-extrabold bg-gradient-to-r from-[#E94D4C] to-[#52B0E4] text-transparent bg-clip-text mr-auto"
     >
       PoApper
     </div>
-    <div class="text-2xl font-bold pb-2">POSTECH 개발자 네트워크</div>
+    <div class="text-3xl md:text-4xl font-bold pb-4">
+      POSTECH 개발자 네트워크
+    </div>
     <a
       href="https://github.com/PoApper"
       target="_blank"
       rel="noopener noreferrer"
-      class="transition ease-in-out delay-100 hover:-translate-y-1 hover:scale-105 duration-300 bg-black hover:bg-gray text-white rounded-[20px] h-[35px] w-[100px]"
+      class="transition ease-in-out delay-100 hover:-translate-y-1 hover:scale-105 duration-300 bg-black hover:bg-gray text-white rounded-[20px] h-[48px] w-[144px]"
     >
-      <div class="h-full flex justify-center py-1">Github</div>
+      <div class="h-full flex items-center justify-center">Github</div>
     </a>
-    <div class="h-1/4"></div>
   </div>
-  <div class="flex flex-col justify-center h-3/4">
+  <div class="flex flex-col justify-center">
     <BubbleWrapper client:load />
   </div>
 </div>

--- a/src/components/section/Navbar.astro
+++ b/src/components/section/Navbar.astro
@@ -4,17 +4,17 @@ import Links from '@/utils/layout'
 
 <header class="sticky my-4 top-4 z-50">
   <nav
-    class="relative flex justify-start items-center mx-8 py-3 px-16 bg-gray-200/50 backdrop-blur-md rounded-[36px]"
+    class="relative flex justify-start items-center mx-8 py-4 px-16 bg-gray-200/50 backdrop-blur-md rounded-[36px]"
   >
     <a href="/" class="mr-auto invisible md:visible">
-      <img class="w-[120px]" src="/logo+name.svg" alt="Logo" />
+      <img class="w-[140px]" src="/logo+name.svg" alt="Logo" />
     </a>
-    <div class="absolute left-6 sm:left-12 md:relative md:left-0">
+    <div class="absolute left-6 sm:left-12 md:relative md:left-0 space-x-4">
       {
         Links.navBarLinks.map((link) => {
           return (
             <a
-              class="transision ease-in-out delay-100 duration-300 hover:text-[#FFFFFF] pr-[10px] font-bold underline"
+              class="transision ease-in-out delay-100 duration-300 hover:text-[#FFFFFF] pr-[10px] font-bold underline text-lg md:text-xl"
               href={link.url}
             >
               {link.name}

--- a/src/components/section/Projects.astro
+++ b/src/components/section/Projects.astro
@@ -5,9 +5,9 @@ import projects from '@utils/projects'
 
 <div class="top-[514px] h-fit w-full p-6 md:px-12 md:py-24">
   <div class="prose py-12">
-    <h3>Projects</h3>
+    <h3 class="text-3xl md:text-4xl">Projects</h3>
   </div>
-  <div class="grid grid-cols-1 gap-4">
+  <div class="grid grid-cols-1 gap-6 md:gap-8">
     {
       projects.projects.map((project) => {
         return (

--- a/src/components/section/Statistics.astro
+++ b/src/components/section/Statistics.astro
@@ -6,31 +6,33 @@ import CommitLog from '@components/hook/statistics.CommitLog'
 
 <section class="w-full bg-black p-12 md:p-24 rounded-none md:rounded-[36px]">
   <div class="prose my-8">
-    <h2 class="text-white">Our History</h2>
+    <h2 class="text-white text-3xl md:text-4xl">Our History</h2>
   </div>
   <div
-    class="flex flex-col md:flex-row justify-center md:justify-around my-10 gap-8"
+    class="flex flex-col md:flex-row justify-center md:justify-around my-10 gap-10"
   >
     <div>
-      <p class="text-white">Established in</p>
+      <p class="text-white text-base md:text-lg">Established in</p>
       <div
-        class="text-4xl font-extrabold bg-gradient-to-r from-[#52B0E4] to-[#F6E565] text-transparent bg-clip-text w-fit"
+        class="text-5xl md:text-6xl font-extrabold bg-gradient-to-r from-[#52B0E4] to-[#F6E565] text-transparent bg-clip-text w-fit"
       >
         2010
       </div>
     </div>
     <div>
-      <p class="text-white">Members Present</p>
+      <p class="text-white text-base md:text-lg">Members Present</p>
       <div
-        class="text-4xl font-extrabold bg-gradient-to-r from-[#F6E565] to-[#E94D4C] text-transparent bg-clip-text w-fit"
+        class="text-5xl md:text-6xl font-extrabold bg-gradient-to-r from-[#F6E565] to-[#E94D4C] text-transparent bg-clip-text w-fit"
       >
         <MemberNum client:load />
       </div>
     </div>
     <div>
-      <p class="text-white">Total Number of Repositories</p>
+      <p class="text-white text-base md:text-lg">
+        Total Number of Repositories
+      </p>
       <div
-        class="text-4xl font-extrabold bg-gradient-to-r from-[#E94D4C] to-[#B4D463] text-transparent bg-clip-text w-fit"
+        class="text-5xl md:text-6xl font-extrabold bg-gradient-to-r from-[#E94D4C] to-[#B4D463] text-transparent bg-clip-text w-fit"
       >
         <RepoNum client:load />
       </div>
@@ -38,7 +40,7 @@ import CommitLog from '@components/hook/statistics.CommitLog'
   </div>
   <div class="border border-solid border-white text-white rounded-md">
     <div
-      class="my-2 mx-4 md:my-3 md:mx-6 break-words whitespace-pre-wrap overflow-x-auto"
+      class="my-2 mx-4 md:my-3 md:mx-6 break-words whitespace-pre-wrap overflow-x-auto text-sm md:text-base"
     >
       <CommitLog client:load />
     </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,9 +10,16 @@ import Footer from '@components/section/Footer.astro'
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <title>PoApper</title>
+    <!-- Pretendard Variable (CDN) -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css"
+    />
     <script is:inline></script>
   </head>
-  <body class="font">
+  <body
+    class="font-sans antialiased text-[17px] leading-[1.65] tracking-[-0.01em] selection:bg-blue-200 selection:text-gray-900"
+  >
     <div class="flex flex-col h-screen justify-between">
       <Navbar />
       <main class="mb-auto mx-4 md:mx-24 my:1 md:my-4">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,21 +6,21 @@ const projectPosts = await getCollection('project')
 ---
 
 <Layout>
-  <article class="prose p-[25px]">
+  <article class="prose prose-lg md:prose-xl p-[25px]">
     <h2>Blog</h2>
   </article>
-  <p class="p-[25px]">
+  <p class="p-[25px] text-lg md:text-xl leading-relaxed">
     PoApper 의 기술 블로그 입니다. PoApper 가 사용하는 기술 스택, 프로젝트, 개발
     경험 등을 공유합니다.
   </p>
 
-  <article class="prose p-[25px]">
+  <article class="prose prose-lg md:prose-xl p-[25px]">
     <h3>Project</h3>
   </article>
-  <ul class="list-disc ml-6">
+  <ul class="list-disc ml-6 text-lg md:text-xl leading-relaxed">
     {
       projectPosts.map((post) => (
-        <li class="hover:underline">
+        <li class="hover:underline mb-2">
           <a href={`/blog/project/${post.slug}`}>
             [{post.data.postDate.toISOString().slice(0, 10)}]{post.data.title}
             by {post.data.writer}

--- a/src/pages/blog/project/[slug].astro
+++ b/src/pages/blog/project/[slug].astro
@@ -27,7 +27,7 @@ const { title, tags, postDate, writer, writer_email } = post.data
 <Layout>
   <div class="my-5">
     <div class="flex justify-evenly">
-      <article class="prose text-center">
+      <article class="prose prose-lg md:prose-xl text-center">
         <h2 class="m-[0px]">{title}</h2>
         <p class="m-[0px]">{postDate.toISOString().slice(0, 10)}</p>
         <a href={`mailto:${writer_email}`}>
@@ -47,8 +47,8 @@ const { title, tags, postDate, writer, writer_email } = post.data
     </div>
   </div>
 
-  <div class="flex justify-center font-sans">
-    <article class="prose text-xm">
+  <div class="flex justify-center">
+    <article class="prose prose-lg md:prose-xl max-w-none">
       <Content />
     </article>
   </div>

--- a/src/pages/people/index.astro
+++ b/src/pages/people/index.astro
@@ -5,11 +5,11 @@ import people from '@utils/people.ts'
 ---
 
 <Layout>
-  <article class="prose p-[25px]">
+  <article class="prose prose-lg md:prose-xl p-[25px]">
     <h2>People</h2>
   </article>
 
-  <article class="prose p-[25px]">
+  <article class="prose prose-lg md:prose-xl p-[25px]">
     <h3>Senior</h3>
   </article>
   <div class="py-1/8 px-1/8">
@@ -23,7 +23,7 @@ import people from '@utils/people.ts'
       }
     </div>
 
-    <article class="prose p-[25px]">
+    <article class="prose prose-lg md:prose-xl p-[25px]">
       <h3>Junior</h3>
     </article>
     <div class="py-1/8 px-1/8">

--- a/src/pages/seminar/index.astro
+++ b/src/pages/seminar/index.astro
@@ -5,10 +5,10 @@ import seminars from '@utils/seminars.ts'
 ---
 
 <Layout>
-  <article class="prose w-full flex flex-col p-[25px]">
+  <article class="prose prose-lg md:prose-xl w-full flex flex-col p-[25px]">
     <h2>Seminar</h2>
   </article>
-  <p class="px-[25px] pb-10">
+  <p class="px-[25px] pb-10 text-lg md:text-xl leading-relaxed">
     포애퍼는 <a href="#reg" class="underline">정기 세미나</a> 와 <a
       href="#irr"
       class="underline">정모 세미나</a
@@ -17,10 +17,10 @@ import seminars from '@utils/seminars.ts'
     있습니다!
   </p>
 
-  <article class="prose w-full flex flex-col p-[25px]">
+  <article class="prose prose-lg md:prose-xl w-full flex flex-col p-[25px]">
     <h3 id="reg">정기 세미나</h3>
   </article>
-  <p class="px-[25px] pb-10">
+  <p class="px-[25px] pb-10 text-lg md:text-xl leading-relaxed">
     정기 세미나는 3개월 동안 진행되며, 세미나를 통해 개발에 대한 기본기를 익힐
     수 있습니다. 프론트엔드, 백엔드, 모바일 세미나를 운영하고 있으며, 수요가
     있을 때는 고급 세미나를 열어 심화된 내용을 다루기도 합니다.
@@ -37,10 +37,10 @@ import seminars from '@utils/seminars.ts'
     </div>
   </div>
 
-  <article class="prose w-full flex flex-col p-[25px]">
+  <article class="prose prose-lg md:prose-xl w-full flex flex-col p-[25px]">
     <h3 id="irr">정모 세미나</h3>
   </article>
-  <p class="px-[25px] pb-10">
+  <p class="px-[25px] pb-10 text-lg md:text-xl leading-relaxed">
     포애퍼 정기 모임에서 개발 관련 이슈와 노하우 등을 공유하는 세미나 입니다.
     누구나 자발적으로 세미나를 진행할 수 있으며, 포애퍼 신규회원을 위한 개발
     입문 세미나와 코딩 테스트, 인턴십, 개발툴 등 다양한 주제를 다루고 있습니다.
@@ -48,7 +48,7 @@ import seminars from '@utils/seminars.ts'
 
   <div class="py-1/8 px-1/8">
     <div class="px-[25px]">
-      <ul class="list-disc ml-6">
+      <ul class="list-disc ml-6 text-lg md:text-xl leading-relaxed">
         {
           seminars.irregular_seminars.map((seminar) => {
             return (

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -2,7 +2,44 @@
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: [
+          'Pretendard Variable',
+          'Noto Sans KR',
+          'system-ui',
+          '-apple-system',
+          'Segoe UI',
+          'Roboto',
+          'Helvetica',
+          'Arial',
+          'Apple SD Gothic Neo',
+          'sans-serif',
+        ],
+      },
+      typography: (theme) => ({
+        DEFAULT: {
+          css: {
+            color: theme('colors.gray.800'),
+            a: {
+              color: theme('colors.gray.900'),
+              textDecoration: 'underline',
+              '&:hover': { color: theme('colors.gray.700') },
+            },
+            h1: { fontWeight: '800' },
+            h2: { fontWeight: '800' },
+            h3: { fontWeight: '700' },
+            code: {
+              backgroundColor: theme('colors.gray.100'),
+              padding: '0.2em 0.35em',
+              borderRadius: '0.25rem',
+            },
+            pre: { lineHeight: '1.6' },
+            img: { margin: '1rem auto' },
+          },
+        },
+      }),
+    },
   },
   plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
## 홈페이지 UI 개선

### 기존
간격이 너무 넓고 글씨 크기가 작음
<img width="1668" height="953" alt="image" src="https://github.com/user-attachments/assets/0de88bad-658b-4252-99a7-c62d547f2f07" />
<img width="1530" height="734" alt="image" src="https://github.com/user-attachments/assets/4f21571c-af99-4904-8bd0-c6c4d7b3983c" />
<img width="1710" height="986" alt="image" src="https://github.com/user-attachments/assets/fcf0e507-4fae-4a90-aa95-9f68751965ab" />


### 개선
- 전체적으로 폰트 사이즈를 키움
- 간격을 좁힘 
- 버블 크기를 키움
- PoApper 소개에 빨간 밑줄을 없앰
<img width="1698" height="930" alt="image" src="https://github.com/user-attachments/assets/25de4413-b73e-419a-85b0-ca24c54851b5" />
<img width="1703" height="834" alt="image" src="https://github.com/user-attachments/assets/22e44f71-feed-4e11-9259-a8de6817db63" />
<img width="1710" height="950" alt="image" src="https://github.com/user-attachments/assets/7dd38ede-019d-47fa-99e1-53dd8e5a57e0" />

